### PR TITLE
Additional properties in v140 should not be allowed, except for sub properties of "_comment"

### DIFF
--- a/metadata/v140/schema.json
+++ b/metadata/v140/schema.json
@@ -207,7 +207,7 @@
             "additionalProperties": false
         },
         "sources": {
-            "description": "List of source objects.",
+            "description": "List of source objects. Each object has all name-value-pairs.",
             "type": "array",
             "items": {
                 "description": "Source object in list of source objects. Each object has all name-value-pairs.",
@@ -276,23 +276,10 @@
                                         "null"
                                     ]
                                 }
-                            },
-                            "required": [
-                                "name",
-                                "title",
-                                "path",
-                                "instruction",
-                                "attribution"
-                            ]
+                            }
                         }
                     }
                 },
-                "required": [
-                    "title",
-                    "description",
-                    "path",
-                    "licenses"
-                ],
                 "additionalProperties": false
             }
         },
@@ -339,13 +326,6 @@
                         ]
                     }
                 },
-                "required": [
-                    "name",
-                    "title",
-                    "path",
-                    "instruction",
-                    "attribution"
-                ],
                 "additionalProperties": false
             }
         },
@@ -353,7 +333,7 @@
             "description": "The people or organizations who contributed to this data package. List of objects.",
             "type": "array",
             "items": {
-                "description": "A person or organizations who contributed to this data package. Each object refers to one contributor. Every contributor must have a title property. All other properties are optional.",
+                "description": "A person or organizations who contributed to this data package. Each object refers to one contributor. Every contributor must have a title and property. A path, email, role and organization properties are optional extras.",
                 "type": "object",
                 "properties": {
                     "title": {
@@ -392,9 +372,6 @@
                         ]
                     }
                 },
-                "required": [
-                    "title"
-                ],
                 "additionalProperties": false
             }
         },
@@ -686,11 +663,5 @@
             "additionalProperties": false
         }
     },
-    "required": [
-        "name",
-        "title",
-        "id",
-        "description"
-    ],
     "additionalProperties": false
 }

--- a/metadata/v140/schema.json
+++ b/metadata/v140/schema.json
@@ -659,8 +659,7 @@
                         "null"
                     ]
                 }
-            },
-            "additionalProperties": false
+            }
         }
     },
     "additionalProperties": false

--- a/metadata/v140/schema.json
+++ b/metadata/v140/schema.json
@@ -386,7 +386,9 @@
                         ]
                     }
                 },
-                "required": ["title"]
+                "required": [
+                    "title"
+                ]
             }
         },
         "resources": {

--- a/metadata/v140/schema.json
+++ b/metadata/v140/schema.json
@@ -119,7 +119,8 @@
                         "null"
                     ]
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "spatial": {
             "description": "Object. Contains name-value-pairs describing the spatial context of the contained data.",
@@ -146,7 +147,8 @@
                         "null"
                     ]
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "temporal": {
             "description": "Temporal object. Time period covered in the data. Temporal information should either contain a \"referenceDate\" or the keys describing a time series; in rare cases both. Use null for the ones that don't apply.",
@@ -198,9 +200,11 @@
                                 "null"
                             ]
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "sources": {
             "description": "List of source objects.",
@@ -288,7 +292,8 @@
                     "description",
                     "path",
                     "licenses"
-                ]
+                ],
+                "additionalProperties": false
             }
         },
         "licenses": {
@@ -340,7 +345,8 @@
                     "path",
                     "instruction",
                     "attribution"
-                ]
+                ],
+                "additionalProperties": false
             }
         },
         "contributors": {
@@ -388,7 +394,8 @@
                 },
                 "required": [
                     "title"
-                ]
+                ],
+                "additionalProperties": false
             }
         },
         "resources": {
@@ -472,7 +479,8 @@
                                                 "null"
                                             ]
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
                             },
                             "primaryKey": {
@@ -523,12 +531,15 @@
                                                         ]
                                                     }
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
                             }
-                        }
+                        },
+                        "additionalProperties": false
                     },
                     "dialect": {
                         "description": "Object. A CSV Dialect defines a simple format to describe the various dialects of CSV files in a language agnostic manner. In case of a database, the values in the containing fields are \"none\".",
@@ -548,9 +559,11 @@
                                     "null"
                                 ]
                             }
-                        }
+                        },
+                        "additionalProperties": false
                     }
-                }
+                },
+                "additionalProperties": false
             }
         },
         "review": {
@@ -571,7 +584,8 @@
                         "null"
                     ]
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "metaMetadata": {
             "description": "Object. Description about the metadata themselves, their format, version and license. These fields should already be provided when you’re filling out your metadata.",
@@ -609,9 +623,11 @@
                                 "null"
                             ]
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "_comment": {
             "description": "Object. The “_comment”-section is used as a self-description of the final metadata-file. It is text, intended for humans and can include a link to the metadata documentation(s), required value formats and similar remarks. The comment section has no fix structure or mandatory values, but a useful self-description, similar to the one depicted here, is encouraged.",
@@ -666,7 +682,8 @@
                         "null"
                     ]
                 }
-            }
+            },
+            "additionalProperties": false
         }
     },
     "required": [
@@ -674,5 +691,6 @@
         "title",
         "id",
         "description"
-    ]
+    ],
+    "additionalProperties": false
 }

--- a/metadata/v140/schema.json
+++ b/metadata/v140/schema.json
@@ -203,7 +203,7 @@
             }
         },
         "sources": {
-            "description": "List of source objects. Each object has all name-value-pairs.",
+            "description": "List of source objects.",
             "type": "array",
             "items": {
                 "description": "Source object in list of source objects. Each object has all name-value-pairs.",
@@ -272,10 +272,23 @@
                                         "null"
                                     ]
                                 }
-                            }
+                            },
+                            "required": [
+                                "name",
+                                "title",
+                                "path",
+                                "instruction",
+                                "attribution"
+                            ]
                         }
                     }
-                }
+                },
+                "required": [
+                    "title",
+                    "description",
+                    "path",
+                    "licenses"
+                ]
             }
         },
         "licenses": {
@@ -320,14 +333,21 @@
                             "null"
                         ]
                     }
-                }
+                },
+                "required": [
+                    "name",
+                    "title",
+                    "path",
+                    "instruction",
+                    "attribution"
+                ]
             }
         },
         "contributors": {
             "description": "The people or organizations who contributed to this data package. List of objects.",
             "type": "array",
             "items": {
-                "description": "A person or organizations who contributed to this data package. Each object refers to one contributor. Every contributor must have a title and property. A path, email, role and organization properties are optional extras.",
+                "description": "A person or organizations who contributed to this data package. Each object refers to one contributor. Every contributor must have a title property. All other properties are optional.",
                 "type": "object",
                 "properties": {
                     "title": {
@@ -365,7 +385,8 @@
                             "null"
                         ]
                     }
-                }
+                },
+                "required": ["title"]
             }
         },
         "resources": {
@@ -645,5 +666,11 @@
                 }
             }
         }
-    }
+    },
+    "required": [
+        "name",
+        "title",
+        "id",
+        "description"
+    ]
 }


### PR DESCRIPTION
Closes #12 

Hi all,

what do you think? Mandatory properties for some objects in metadata? Yes, no, maybe :wink: 

Let's discuss!

Context: (i) https://github.com/OpenEnergyPlatform/metadata/issues/9#issuecomment-551908556, (ii) https://github.com/OpenEnergyPlatform/metadata/issues/9#issuecomment-551925124